### PR TITLE
Added: ordinal support

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ WordsToNumber.convert("دوازده هزار بیست دو", { addCommas: true }
 
 NumberToWords.convert(500443) // "پانصد هزار و چهار صد و چهل و سه"
 NumberToWords.convert("500,443") // "پانصد هزار و چهار صد و چهل و سه"
+NumberToWords.convert("500,443", { ordinal: true }) // "پانصد هزار و چهار صد و چهل و سوم"
 NumberToWords.convert(30000000000) // "سی میلیارد"
 });
 ```

--- a/src/modules/NumberToWords.ts
+++ b/src/modules/NumberToWords.ts
@@ -1,7 +1,12 @@
 import { trim } from "../helpers";
 import removeCommas from "./removeCommas";
+import addOrdinalSuffix from "./addOrdinalSuffix";
 
 // <Refrence path="https://fa.wikipedia.org/wiki/۱۰۰۰۰۰۰۰۰۰_(عدد)" />
+
+interface IOption {
+	ordinal?: boolean;
+}
 
 interface INumberToWord {
 	[key: string]: string;
@@ -76,7 +81,8 @@ class NumberToWords {
 		return result;
 	};
 
-	public convert(number: bigint | number | string): string | undefined {
+
+	public convert(number: bigint | number | string, { ordinal = false }: IOption = {}): string | undefined {
 		if (!number) return;
 
 		if (number === 0) {
@@ -112,7 +118,12 @@ class NumberToWords {
 			words = words.slice(0, -3);
 		}
 
-		return trim(isNegative ? `منفی ${words}` : words);
+		words = trim(isNegative ? `منفی ${words}` : words);
+
+		if(ordinal)
+			words = addOrdinalSuffix(words)!; 
+		
+		return words;
 	}
 }
 

--- a/src/modules/WordsToNumber.ts
+++ b/src/modules/WordsToNumber.ts
@@ -1,6 +1,7 @@
 import addCommasFn from "./addCommas";
 import { replaceArray } from "../helpers";
 import { digitsEnToFa, digitsFaToEn } from "./digits";
+import removeOrdinalSuffix from "./removeOrdinalSuffix";
 
 // <Refrence path='https://fa.wikipedia.org/wiki/الگو:عدد_به_حروف/توضیحات' />
 // https://fa.wikipedia.org/wiki/۱۰۰۰۰۰۰۰۰۰_(عدد)
@@ -104,7 +105,8 @@ class WordsToNumber {
 	}
 	private tokenize(words: string): number[] {
 		let replacedWords = replaceArray(words, this.otherAdjective);
-		replacedWords = replacedWords.replace(new RegExp("(مین|م)$", "ig"), "");
+		replacedWords = replacedWords.replace(new RegExp("مین$", "ig"), "");
+		replacedWords = removeOrdinalSuffix(replacedWords)!;
 
 		const result: number[] = [];
 		const splittedWords: string[] = replacedWords.split(" ");

--- a/src/modules/addOrdinalSuffix.ts
+++ b/src/modules/addOrdinalSuffix.ts
@@ -1,0 +1,19 @@
+/**
+ * Add Ordinal suffix to numbers
+ * @method addOrdinalSuffix
+ * @param   {number}  string Number, eg: "300000"
+ * @return  {string}  		 Return a string of ordinal number
+ */
+const addOrdinalSuffix = (number?: string): string | undefined => {
+	if (typeof number === "undefined") return;
+
+    if (number.slice(-1) == "ی") {
+		number += " اُم";
+    } else if (number.slice(-2) == "سه") {
+		number = number.slice(0, -2) + "سوم";
+	} else number += "م";
+    
+    return number;
+};
+
+export default addOrdinalSuffix;

--- a/src/modules/removeOrdinalSuffix.ts
+++ b/src/modules/removeOrdinalSuffix.ts
@@ -1,0 +1,20 @@
+/**
+ * Remove Ordinal suffix to numbers
+ * @method removeOrdinalSuffix
+ * @param   {number}  string Number, eg: "سه هزارم"
+ * @return  {string}  		 Return a string of ordinal number
+ */
+const removeOrdinalSuffix = (number?: string): string | undefined => {
+	if (typeof number === "undefined") return;
+
+	number = number.replace(new RegExp("(ام| اُم)$", "ig"), "")
+	if (number.slice(-3) == "سوم") {
+		number = number.slice(0, -3) + "سه";
+	} else if (number.slice(-1) == "م") {
+		number = number.slice(0, -1);
+	}
+
+	return number;
+};
+
+export default removeOrdinalSuffix;

--- a/test/NumberToWords.spec.ts
+++ b/test/NumberToWords.spec.ts
@@ -5,4 +5,10 @@ it("NumberToWords", () => {
 	expect(NumberToWords.convert("500,443")).toEqual("پانصد هزار و چهار صد و چهل و سه");
 	expect(NumberToWords.convert(500)).toHaveLength(5);
 	expect(NumberToWords.convert(30000000000)).toEqual("سی میلیارد");
+
+
+	expect(NumberToWords.convert("500,443", { ordinal: true })).toEqual("پانصد هزار و چهار صد و چهل و سوم");
+	expect(NumberToWords.convert(-30, { ordinal: true })).toEqual("منفی سی اُم");
+	expect(NumberToWords.convert(33, { ordinal: true })).toEqual("سی و سوم");
+	expect(NumberToWords.convert(45, { ordinal: true })).toEqual("چهل و پنجم");
 });

--- a/test/WordsToNumber.spec.ts
+++ b/test/WordsToNumber.spec.ts
@@ -9,6 +9,8 @@ it("WordsToNumber", () => {
 	expect(WordsToNumber.convert("سه هزار دویست و دوازده")).toEqual(3212);
 	expect(WordsToNumber.convert("منفی سه هزارمین")).not.toEqual("-3000");
 	expect(String(WordsToNumber.convert("منفی سه هزارمین"))).toHaveLength(5);
+	expect(WordsToNumber.convert("منفی سی اُم")).toEqual(-30);
+	expect(WordsToNumber.convert("سی و سوم")).toEqual(33);
 
 	expect(WordsToNumber.convert("دوازده هزار بیست دو")).toEqual(12022);
 	expect(WordsToNumber.convert("دوازده هزار بیست دو", { addCommas: true })).toEqual("12,022");

--- a/test/addOrdinalSuffix.spec.ts
+++ b/test/addOrdinalSuffix.spec.ts
@@ -1,0 +1,8 @@
+import addOrdinalSuffix from "../src/modules/addOrdinalSuffix";
+
+it("Add ordinal suffix", () => {
+	expect(addOrdinalSuffix("چهل و سه")).toEqual("چهل و سوم");
+	expect(addOrdinalSuffix("چهل و پنج")).toEqual("چهل و پنجم");
+	expect(addOrdinalSuffix("سی")).toEqual("سی اُم");
+	expect(addOrdinalSuffix()).toBeUndefined();
+});

--- a/test/removeOrdinalSuffix.spec.ts
+++ b/test/removeOrdinalSuffix.spec.ts
@@ -1,0 +1,8 @@
+import removeOrdinalSuffix from "../src/modules/removeOrdinalSuffix";
+
+it("Remove ordinal suffix", () => {
+	expect(removeOrdinalSuffix("چهل و سوم")).toEqual("چهل و سه");
+	expect(removeOrdinalSuffix("چهل و پنجم")).toEqual("چهل و پنج");
+	expect(removeOrdinalSuffix("سی اُم")).toEqual("سی");
+	expect(removeOrdinalSuffix()).toBeUndefined();
+});


### PR DESCRIPTION
**What:**

- Ordinal support added resolving #12 (add & remove suffix) 

Why:

- Ordinal is a number defining the position of something in a series, such as `دوم`, `یکم`, or `سوم` 
- Ordinal numbers are used as adjectives, nouns, and pronouns

**How:**

- Set ordinal option in convert function
- Exec removeOrdinalSuffix in WordsToNumber convert function
- Add test cases
- Upgrade #README.md
