### PR TITLE
Feature/URLfix

### DIFF
--- a/src/modules/URLfix/index.ts
+++ b/src/modules/URLfix/index.ts
@@ -5,9 +5,9 @@
  * @return a string of fixed URL
  */
 function URLfix(url?: string): string | undefined {
-    if (!url) return;
+	if (!url) return;
 
-    return decodeURIComponent(url);
+	return decodeURIComponent(url);
 }
 
 export default URLfix;

--- a/src/modules/URLfix/index.ts
+++ b/src/modules/URLfix/index.ts
@@ -2,21 +2,20 @@
  * @method URLfix
  * @description Used for fix Persian characters in URL
  * @param {string} url
- * @param {string} separator - optional argument to replace Character with space in URLs. by default return with space
+ * @param {string} separator - optional argument to replace character with space in URLs. by default return URL with space
  * @example
  * URLfix('https://fa.wikipedia.org/wiki/%D9%85%DA%A9%D8%A7%D9%86%DB%8C%DA%A9%20%DA%A9%D9%88%D8%A7%D9%86%D8%AA%D9%88%D9%85%DB%8C', '_')
  * return 'https://fa.wikipedia.org/wiki/مکانیک_کوانتومی'
- * @return a string of fixed URL
+ * @return {string} a string of fixed URL
  */
+
 function URLfix(url?: string, separator?: string): string | undefined {
 	if (!url) return;
 	url = decodeURIComponent(url);
 
-	if (separator) {
-		url = url.replace(" ", separator);
-	}
+	if (separator) return url.replace(" ", separator);
 
 	return url;
 }
 
-export default URLfix;
+export default URLfix

--- a/src/modules/URLfix/index.ts
+++ b/src/modules/URLfix/index.ts
@@ -9,14 +9,14 @@
  * @return a string of fixed URL
  */
 function URLfix(url?: string, separator?: string): string | undefined {
-    if (!url) return;
-    url = decodeURIComponent(url)
+	if (!url) return;
+	url = decodeURIComponent(url);
 
-    if (separator) {
-        url = url.replace(" ", separator)
-    }
+	if (separator) {
+		url = url.replace(" ", separator);
+	}
 
-    return url;
+	return url;
 }
 
 export default URLfix;

--- a/src/modules/URLfix/index.ts
+++ b/src/modules/URLfix/index.ts
@@ -2,12 +2,21 @@
  * @method URLfix
  * @description Used for fix Persian characters in URL
  * @param {string} url
+ * @param {string} separator - optional argument to replace Character with space in URLs. by default return with space
+ * @example
+ * URLfix('https://fa.wikipedia.org/wiki/%D9%85%DA%A9%D8%A7%D9%86%DB%8C%DA%A9%20%DA%A9%D9%88%D8%A7%D9%86%D8%AA%D9%88%D9%85%DB%8C', '_')
+ * return 'https://fa.wikipedia.org/wiki/مکانیک_کوانتومی'
  * @return a string of fixed URL
  */
-function URLfix(url?: string): string | undefined {
-	if (!url) return;
+function URLfix(url?: string, separator?: string): string | undefined {
+    if (!url) return;
+    url = decodeURIComponent(url)
 
-	return decodeURIComponent(url);
+    if (separator) {
+        url = url.replace(" ", separator)
+    }
+
+    return url;
 }
 
 export default URLfix;

--- a/src/modules/URLfix/index.ts
+++ b/src/modules/URLfix/index.ts
@@ -1,31 +1,13 @@
 /**
- * Used for fix Persian characters in URL
- *
  * @method URLfix
- * @param URL string
- * @return A string of fixed URL
+ * @description Used for fix Persian characters in URL
+ * @param {string} url
+ * @return a string of fixed URL
  */
-const URLfix = (value?: string): string | undefined => {
-	if (!value) {
-		return;
-	}
+function URLfix(url?: string): string | undefined {
+    if (!url) return;
 
-	// Replace every %20 with _ to protect them from decodeURI
-	let old = "";
-	while (old !== value) {
-		old = value;
-		value = value.replace(/(http\S+?)%20/g, "$1\u200c\u200c\u200c_\u200c\u200c\u200c");
-	}
-
-	// Decode URIs
-	// NOTE: This would convert all %20's to _'s which could break some links
-	// but we will undo that later on
-	value = value.replace(/(http\S+)/g, (_, p) => decodeURI(p));
-
-	// Revive all instances of %20 to make sure no links is broken
-	value = value.replace(/\u200c\u200c\u200c_\u200c\u200c\u200c/g, "%20");
-
-	return value;
-};
+    return decodeURIComponent(url);
+}
 
 export default URLfix;

--- a/src/modules/URLfix/index.ts
+++ b/src/modules/URLfix/index.ts
@@ -18,4 +18,4 @@ function URLfix(url?: string, separator?: string): string | undefined {
 	return url;
 }
 
-export default URLfix
+export default URLfix;

--- a/test/URLfix.spec.ts
+++ b/test/URLfix.spec.ts
@@ -5,6 +5,7 @@ it("URLfix", () => {
     expect(URLfix("https://en.wikipedia.org/wiki/Persian_alphabet")).toEqual("https://en.wikipedia.org/wiki/Persian_alphabet",);
     expect(URLfix('https://fa.wikipedia.org/wiki/%D8%AF%DB%8C%D8%A7%DA%A9%D9%88')).toEqual('https://fa.wikipedia.org/wiki/دیاکو')
     expect(URLfix('https://fa.wikipedia.org/wiki/%D9%85%DA%A9%D8%A7%D9%86%DB%8C%DA%A9%20%DA%A9%D9%88%D8%A7%D9%86%D8%AA%D9%88%D9%85%DB%8C', '_')).toEqual('https://fa.wikipedia.org/wiki/مکانیک_کوانتومی')
+    expect(URLfix('https://fa.wikipedia.org/wiki/%D9%85%DA%A9%D8%A7%D9%86%DB%8C%DA%A9%20%DA%A9%D9%88%D8%A7%D9%86%D8%AA%D9%88%D9%85%DB%8C', '-')).toEqual('https://fa.wikipedia.org/wiki/مکانیک-کوانتومی')
     expect(URLfix("Sample Text")).toEqual("Sample Text");
     expect(URLfix()).toBeUndefined();
 });

--- a/test/URLfix.spec.ts
+++ b/test/URLfix.spec.ts
@@ -1,14 +1,18 @@
-import { URLfix } from "../src";
+import {URLfix} from "../src";
 
 it("URLfix", () => {
-	expect(
-		URLfix(
-			"https://fa.wikipedia.org/wiki/%D9%85%D8%AF%DB%8C%D8%A7%D9%88%DB%8C%DA%A9%DB%8C:Gadget-Extra-Editbuttons-botworks.js",
-		),
-	).toEqual("https://fa.wikipedia.org/wiki/مدیاویکی:Gadget-Extra-Editbuttons-botworks.js");
-	expect(URLfix("https://en.wikipedia.org/wiki/Persian_alphabet")).toEqual(
-		"https://en.wikipedia.org/wiki/Persian_alphabet",
-	);
-	expect(URLfix()).toBeUndefined();
-	expect(URLfix("Sample Text")).toEqual("Sample Text");
+    expect(
+        URLfix(
+            "https://fa.wikipedia.org/wiki/%D9%85%D8%AF%DB%8C%D8%A7%D9%88%DB%8C%DA%A9%DB%8C:Gadget-Extra-Editbuttons-botworks.js",
+        ),
+    ).toEqual("https://fa.wikipedia.org/wiki/مدیاویکی:Gadget-Extra-Editbuttons-botworks.js");
+
+    expect(URLfix("https://en.wikipedia.org/wiki/Persian_alphabet")).toEqual(
+        "https://en.wikipedia.org/wiki/Persian_alphabet",
+    );
+
+    expect(URLfix('https://fa.wikipedia.org/wiki/%D8%AF%DB%8C%D8%A7%DA%A9%D9%88')).toEqual('https://fa.wikipedia.org/wiki/دیاکو')
+    expect(URLfix('https://fa.wikipedia.org/wiki/%D9%85%DA%A9%D8%A7%D9%86%DB%8C%DA%A9%20%DA%A9%D9%88%D8%A7%D9%86%D8%AA%D9%88%D9%85%DB%8C')).toEqual('https://fa.wikipedia.org/wiki/مکانیک کوانتومی')
+    expect(URLfix("Sample Text")).toEqual("Sample Text");
+    expect(URLfix()).toBeUndefined();
 });

--- a/test/URLfix.spec.ts
+++ b/test/URLfix.spec.ts
@@ -1,18 +1,10 @@
 import {URLfix} from "../src";
 
 it("URLfix", () => {
-    expect(
-        URLfix(
-            "https://fa.wikipedia.org/wiki/%D9%85%D8%AF%DB%8C%D8%A7%D9%88%DB%8C%DA%A9%DB%8C:Gadget-Extra-Editbuttons-botworks.js",
-        ),
-    ).toEqual("https://fa.wikipedia.org/wiki/مدیاویکی:Gadget-Extra-Editbuttons-botworks.js");
-
-    expect(URLfix("https://en.wikipedia.org/wiki/Persian_alphabet")).toEqual(
-        "https://en.wikipedia.org/wiki/Persian_alphabet",
-    );
-
+    expect(URLfix("https://fa.wikipedia.org/wiki/%D9%85%D8%AF%DB%8C%D8%A7%D9%88%DB%8C%DA%A9%DB%8C:Gadget-Extra-Editbuttons-botworks.js",),).toEqual("https://fa.wikipedia.org/wiki/مدیاویکی:Gadget-Extra-Editbuttons-botworks.js");
+    expect(URLfix("https://en.wikipedia.org/wiki/Persian_alphabet")).toEqual("https://en.wikipedia.org/wiki/Persian_alphabet",);
     expect(URLfix('https://fa.wikipedia.org/wiki/%D8%AF%DB%8C%D8%A7%DA%A9%D9%88')).toEqual('https://fa.wikipedia.org/wiki/دیاکو')
-    expect(URLfix('https://fa.wikipedia.org/wiki/%D9%85%DA%A9%D8%A7%D9%86%DB%8C%DA%A9%20%DA%A9%D9%88%D8%A7%D9%86%D8%AA%D9%88%D9%85%DB%8C')).toEqual('https://fa.wikipedia.org/wiki/مکانیک کوانتومی')
+    expect(URLfix('https://fa.wikipedia.org/wiki/%D9%85%DA%A9%D8%A7%D9%86%DB%8C%DA%A9%20%DA%A9%D9%88%D8%A7%D9%86%D8%AA%D9%88%D9%85%DB%8C', '_')).toEqual('https://fa.wikipedia.org/wiki/مکانیک_کوانتومی')
     expect(URLfix("Sample Text")).toEqual("Sample Text");
     expect(URLfix()).toBeUndefined();
 });


### PR DESCRIPTION
I erased almost all codes in **urlfix.ts** file and just use **_decodeUriComponent_**. and still all of our test are passed successfully. :open_mouth: 

### hint : 
+ we don't need to replace **%20** with **_** because in each site is different for example varzesh3 is hyphen but wikipedia is underscore

we can get separator char as argument for replacing or let user manipulate returned value,

@ali-master what you think ?