### PR TITLE
chore: :arrow_up: Upgrade y18n version to 5.0.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2938,7 +2938,7 @@
 				"rimraf": "^2.6.3",
 				"ssri": "^6.0.1",
 				"unique-filename": "^1.1.1",
-				"y18n": "^4.0.0"
+				"y18n": "^5.0.8"
 			},
 			"dependencies": {
 				"lru-cache": {
@@ -14358,9 +14358,9 @@
 					}
 				},
 				"y18n": {
-					"version": "5.0.5",
-					"resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.5.tgz",
-					"integrity": "sha512-hsRUr4FFrvhhRH12wOdfs38Gy7k2FFzB9qgN9v3aLykRq0dRcdcpz5C9FxdS2NuhOrI/628b/KSTJ3rwHysYSg==",
+					"version": "5.0.8",
+					"resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+					"integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
 					"dev": true
 				},
 				"yargs": {
@@ -16462,9 +16462,9 @@
 			"dev": true
 		},
 		"y18n": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-			"integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+			"version": "5.0.8",
+			"resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+			"integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
 			"dev": true
 		},
 		"yallist": {
@@ -16494,7 +16494,7 @@
 				"set-blocking": "^2.0.0",
 				"string-width": "^4.2.0",
 				"which-module": "^2.0.0",
-				"y18n": "^4.0.0",
+				"y18n": "^5.0.8",
 				"yargs-parser": "^18.1.2"
 			},
 			"dependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2418,7 +2418,7 @@
     "rimraf" "^2.6.3"
     "ssri" "^6.0.1"
     "unique-filename" "^1.1.1"
-    "y18n" "^4.0.0"
+    "y18n" "^5.0.8"
 
 "cache-base@^1.0.1":
   "integrity" "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ=="
@@ -9883,15 +9883,10 @@
   "resolved" "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz"
   "version" "4.0.2"
 
-"y18n@^4.0.0":
-  "integrity" "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w=="
-  "resolved" "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz"
-  "version" "4.0.0"
-
-"y18n@^5.0.5":
-  "integrity" "sha512-hsRUr4FFrvhhRH12wOdfs38Gy7k2FFzB9qgN9v3aLykRq0dRcdcpz5C9FxdS2NuhOrI/628b/KSTJ3rwHysYSg=="
-  "resolved" "https://registry.npmjs.org/y18n/-/y18n-5.0.5.tgz"
-  "version" "5.0.5"
+"y18n@^5.0.8":
+  "integrity" "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="
+  "resolved" "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz"
+  "version" "5.0.8"
 
 "yallist@^3.0.2":
   "integrity" "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
@@ -9935,7 +9930,7 @@
     "set-blocking" "^2.0.0"
     "string-width" "^4.2.0"
     "which-module" "^2.0.0"
-    "y18n" "^4.0.0"
+    "y18n" "^5.0.8"
     "yargs-parser" "^18.1.2"
 
 "yargs@^16.0.0":
@@ -9948,7 +9943,7 @@
     "get-caller-file" "^2.0.5"
     "require-directory" "^2.1.1"
     "string-width" "^4.2.0"
-    "y18n" "^5.0.5"
+    "y18n" "^5.0.8"
     "yargs-parser" "^20.2.2"
 
 "yn@3.1.1":


### PR DESCRIPTION
Version 4 of y18n is vulnerable to prototype pollution https://npmjs.com/advisories/1654