### PR TITLE
chore: add npm-publish ci

### DIFF
--- a/.github/workflows/npm-publish-beta.yml
+++ b/.github/workflows/npm-publish-beta.yml
@@ -1,12 +1,23 @@
-name: Release
+name: Beta Release
 
 on:
-  push:
-    tags:
-      - 'v*.*.*'
+    push:
+        branches: [develop]
 
 jobs:
+  release-beta:
+      runs-on: ubuntu-latest
+      steps:
+        - name: Checkout
+          uses: actions/checkout@v2
+        - name: Standard Version
+          run: |
+            npm ci
+            release:beta
+            git push --follow-tags origin develop
+
   release-tag:
+      needs: release-beta
       runs-on: ubuntu-latest
       steps:
         - name: Checkout
@@ -15,18 +26,9 @@ jobs:
           uses: softprops/action-gh-release@v1
           env:
             GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  build:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
-        with:
-          node-version: 14
-      - run: npm ci
-      - run: npm run micro:build
 
   publish-npm:
-    needs: build
+    needs: release-beta
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -40,7 +42,7 @@ jobs:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
 
   publish-gpr:
-    needs: build
+    needs: release-beta
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,57 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+jobs:
+  release-tag:
+      runs-on: ubuntu-latest
+      steps:
+        - name: Checkout
+          uses: actions/checkout@v2
+        - name: Release
+          uses: softprops/action-gh-release@v1
+          env:
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 14
+      - run: npm ci
+      - run: npm run micro:build
+
+  publish-npm:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 14
+          registry-url: https://registry.npmjs.org/
+      - run: npm ci
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
+
+  publish-gpr:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 14
+          registry-url: https://npm.pkg.github.com/
+      - run: npm ci
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
**What:**

- npm-publish.yml added

**Why:**

- Deploy faster and more confidently with distributed tracing for CI/CD.

**How:**

1.  `npm run release`
2. push the tag `git push --follow-tags origin develop`
3. `npm-publish.yml` will create a release & publish it to NPM & GPR automatically

**Note:** I want to automate `npm run release` in the future PRs

**ToDo:** 

- [ ] Test