### PR TITLE
fix: wordsToNumber return 0 for MAGNITUDE constants

### DIFF
--- a/src/modules/wordsToNumber/index.ts
+++ b/src/modules/wordsToNumber/index.ts
@@ -39,7 +39,7 @@ function compute(tokens: string[]): number {
 		} else if (!isNaN(Number(token))) {
 			sum += parseInt(token, 10);
 		} else {
-			sum *= MAGNITUDE[token];
+			sum === 0 ? (sum = MAGNITUDE[token]) : (sum *= MAGNITUDE[token]);
 		}
 	});
 	return isNegative ? sum * -1 : sum;

--- a/test/wordsToNumber.spec.ts
+++ b/test/wordsToNumber.spec.ts
@@ -1,4 +1,5 @@
 import { wordsToNumber } from "../src";
+import { UNITS, TEN, MAGNITUDE } from "../src/modules/wordsToNumber/constants";
 
 describe("WordsToNumber", () => {
 	it("Should convert truly", () => {
@@ -72,5 +73,32 @@ describe("WordsToNumber", () => {
 		expect(
 			wordsToNumber<number>("ضد و بنچاه و دو", { fuzzy: true }),
 		).toEqual(152);
+	});
+
+	describe("UNITS", () => {
+		Object.entries(UNITS).forEach(pair => {
+			const [key, value] = pair;
+			it(`${value}`, () => {
+				expect(wordsToNumber(key)).toEqual(value);
+			});
+		})
+	});
+
+	describe("TEN", () => {
+		Object.entries(TEN).forEach((pair) => {
+			const [key, value] = pair;
+			it(`${value}`, () => {
+				expect(wordsToNumber(key)).toEqual(value);
+			});
+		});
+	});
+
+	describe("MAGNITUDE", () => {
+		Object.entries(MAGNITUDE).forEach((pair) => {
+			const [key, value] = pair;
+			it(`${value}`, () => {
+				expect(wordsToNumber(key)).toEqual(value);
+			});
+		});
 	});
 });


### PR DESCRIPTION
- Update tests for UNITS, TEN, and MAGNITUDE constants
fixes #107 