### PR TITLE
fix(nationalId): add check mono ids

### DIFF
--- a/src/modules/nationalId/index.ts
+++ b/src/modules/nationalId/index.ts
@@ -24,14 +24,14 @@ function verifyIranianNationalId(nationalId?: string | number): boolean | undefi
 
 	if (code in notAllowedDigits) return false;
 	if (codeLength < 8 || codeLength > 10) return false;
-	code = ("00" + code).substr(codeLength + 2 - 10);
-	if (+code.substr(3, 6) === 0) return false;
+	code = ("00" + code).substring(codeLength + 2 - 10);
+	if (+code.substring(3, 9) === 0) return false;
 
-	const lastNumber = +code.substr(9, 1);
+	const lastNumber = +code.substring(9);
 	let sum = 0;
 
 	for (let i = 0; i < 9; i++) {
-		sum += +code.substr(i, 1) * (10 - i);
+		sum += +code.substring(i, i + 1) * (10 - i);
 	}
 
 	sum = sum % 11;

--- a/src/modules/nationalId/index.ts
+++ b/src/modules/nationalId/index.ts
@@ -10,9 +10,8 @@ function verifyIranianNationalId(nationalId?: string | number): boolean | undefi
 	if (!nationalId) return;
 	let code = nationalId.toString();
 	const codeLength = code.length;
-	const monoDigit = [
+	const monoDigits = [
 		"0000000000",
-		"1111111111",
 		"2222222222",
 		"3333333333",
 		"4444444444",
@@ -23,16 +22,16 @@ function verifyIranianNationalId(nationalId?: string | number): boolean | undefi
 		"9999999999",
 	];
 
-	if (codeLength < 8 || codeLength > 10 || parseInt(code, 10) == 0) return false;
-	code = ("0000" + code).substr(codeLength + 4 - 10);
-	if (parseInt(code.substr(3, 6), 10) == 0) return false;
-	if (monoDigit.indexOf(code) > -1) return false;
+	if (monoDigits.indexOf(code) > -1) return false;
+	if (codeLength < 8 || codeLength > 10) return false;
+	code = ("00" + code).substr(codeLength + 2 - 10);
+	if (+code.substr(3, 6) === 0) return false;
 
-	const lastNumber = parseInt(code.substr(9, 1), 10);
+	const lastNumber = +code.substr(9, 1);
 	let sum = 0;
 
 	for (let i = 0; i < 9; i++) {
-		sum += parseInt(code.substr(i, 1), 10) * (10 - i);
+		sum += +code.substr(i, 1) * (10 - i);
 	}
 
 	sum = sum % 11;

--- a/src/modules/nationalId/index.ts
+++ b/src/modules/nationalId/index.ts
@@ -2,30 +2,42 @@
  * Check National-id validation
  * @category National id
  * @method verifyIranianNationalId
- * @param  {String?}          nationalId [String of national id - like this: 1111111111]
+ * @param  {String?}          nationalId [String of national id - like this: 0018465986]
  * @return {Boolean}                    [valid or no]
  */
-function verifyIranianNationalId(nationalId?: string | number): boolean | null | undefined {
+
+function verifyIranianNationalId(nationalId?: string | number): boolean | undefined {
 	if (!nationalId) return;
-	else {
-		let code = nationalId.toString();
+	let code = nationalId.toString();
+	const codeLength = code.length;
+	const monoDigit = [
+		"0000000000",
+		"1111111111",
+		"2222222222",
+		"3333333333",
+		"4444444444",
+		"5555555555",
+		"6666666666",
+		"7777777777",
+		"8888888888",
+		"9999999999",
+	];
 
-		if (!code.match(/^\d{10}$/)) return false;
-		code = ("0000" + code).substr(code.length + 4 - 10);
+	if (codeLength < 8 || codeLength > 10 || parseInt(code, 10) == 0) return false;
+	code = ("0000" + code).substr(codeLength + 4 - 10);
+	if (parseInt(code.substr(3, 6), 10) == 0) return false;
+	if (monoDigit.indexOf(code) > -1) return false;
 
-		if (parseInt(code.substr(3, 6), 10) === 0) return false;
+	const lastNumber = parseInt(code.substr(9, 1), 10);
+	let sum = 0;
 
-		const lastNumber = parseInt(code.substr(9, 1), 10);
-		let sum = 0;
-
-		for (let i = 0; i < 9; i++) {
-			sum += parseInt(code.substr(i, 1), 10) * (10 - i);
-		}
-
-		sum = sum % 11;
-
-		return (sum < 2 && lastNumber === sum) || (sum >= 2 && lastNumber === 11 - sum);
+	for (let i = 0; i < 9; i++) {
+		sum += parseInt(code.substr(i, 1), 10) * (10 - i);
 	}
+
+	sum = sum % 11;
+
+	return (sum < 2 && lastNumber === sum) || (sum >= 2 && lastNumber === 11 - sum);
 }
 
 export default verifyIranianNationalId;

--- a/src/modules/nationalId/index.ts
+++ b/src/modules/nationalId/index.ts
@@ -10,19 +10,19 @@ function verifyIranianNationalId(nationalId?: string | number): boolean | undefi
 	if (!nationalId) return;
 	let code = nationalId.toString();
 	const codeLength = code.length;
-	const monoDigits = [
-		"0000000000",
-		"2222222222",
-		"3333333333",
-		"4444444444",
-		"5555555555",
-		"6666666666",
-		"7777777777",
-		"8888888888",
-		"9999999999",
-	];
+	const notAllowedDigits = {
+		"0000000000": true,
+		"2222222222": true,
+		"3333333333": true,
+		"4444444444": true,
+		"5555555555": true,
+		"6666666666": true,
+		"7777777777": true,
+		"8888888888": true,
+		"9999999999": true,
+	};
 
-	if (monoDigits.indexOf(code) > -1) return false;
+	if (code in notAllowedDigits) return false;
 	if (codeLength < 8 || codeLength > 10) return false;
 	code = ("00" + code).substr(codeLength + 2 - 10);
 	if (+code.substr(3, 6) === 0) return false;

--- a/test/verifyIranianNationalId.spec.ts
+++ b/test/verifyIranianNationalId.spec.ts
@@ -17,7 +17,7 @@ it("Validation of Iranian National Number(code-e Melli)", () => {
 	expect(verifyIranianNationalId(123000000)).toBeFalsy();
 	expect(verifyIranianNationalId(1230000000)).toBeFalsy();
 	expect(verifyIranianNationalId("0000000000")).toBeFalsy();
-	expect(verifyIranianNationalId("1111111111")).toBeFalsy();
+	expect(verifyIranianNationalId("1111111111")).not.toBeFalsy();
 	expect(verifyIranianNationalId("4444444444")).toBeFalsy();
 	expect(verifyIranianNationalId("9999999999")).toBeFalsy();
 	expect(verifyIranianNationalId("12300000")).toBeFalsy();

--- a/test/verifyIranianNationalId.spec.ts
+++ b/test/verifyIranianNationalId.spec.ts
@@ -1,20 +1,34 @@
 import { verifyIranianNationalId } from "../src";
 
+// https://www.searchline.ir/idcode
+
 it("Validation of Iranian National Number(code-e Melli)", () => {
-	expect(verifyIranianNationalId(123000000)).toBeFalsy();
-	expect(verifyIranianNationalId("0000000000")).toBeFalsy();
 	expect(verifyIranianNationalId("")).toBeUndefined();
 	expect(verifyIranianNationalId()).toBeUndefined();
-
+	expect(verifyIranianNationalId(0)).toBeUndefined();
+	expect(verifyIranianNationalId(12345)).toBeFalsy();
+	expect(verifyIranianNationalId("0")).toBeFalsy();
+	expect(verifyIranianNationalId("000000")).toBeFalsy();
+	expect(verifyIranianNationalId("12345")).toBeFalsy();
+	expect(verifyIranianNationalId(11537027)).not.toBeFalsy();
+	expect(verifyIranianNationalId(787833770)).not.toBeFalsy();
+	expect(verifyIranianNationalId(1583250689)).not.toBeFalsy();
+	expect(verifyIranianNationalId(12300000)).toBeFalsy();
+	expect(verifyIranianNationalId(123000000)).toBeFalsy();
+	expect(verifyIranianNationalId(1230000000)).toBeFalsy();
+	expect(verifyIranianNationalId("0000000000")).toBeFalsy();
+	expect(verifyIranianNationalId("1111111111")).toBeFalsy();
+	expect(verifyIranianNationalId("4444444444")).toBeFalsy();
+	expect(verifyIranianNationalId("9999999999")).toBeFalsy();
+	expect(verifyIranianNationalId("12300000")).toBeFalsy();
+	expect(verifyIranianNationalId("123000000")).toBeFalsy();
+	expect(verifyIranianNationalId("1230000000")).toBeFalsy();
 	expect(verifyIranianNationalId("0499370899")).not.toBeFalsy();
-	// https://www.yjc.ir/fa/news/6787095/%D8%B1%D9%86%D8%AF%D8%AA%D8%B1%DB%8C%D9%86-%D8%B4%D9%85%D8%A7%D8%B1%D9%87-%D9%85%D9%84%DB%8C-%DA%A9%D8%B4%D9%88%D8%B1-%D8%B1%D8%A7-%D8%A8%D8%B4%D9%86%D8%A7%D8%B3%DB%8C%D8%AF
-	expect(verifyIranianNationalId("1111111111")).not.toBeFalsy();
 	expect(verifyIranianNationalId("0790419904")).not.toBeFalsy();
 	expect(verifyIranianNationalId("0084575948")).not.toBeFalsy();
 	expect(verifyIranianNationalId("0963695398")).not.toBeFalsy();
 	expect(verifyIranianNationalId("0684159414")).not.toBeFalsy();
 	expect(verifyIranianNationalId("0067749828")).not.toBeFalsy();
-
 	expect(verifyIranianNationalId("0650451252")).not.toBeFalsy();
 	expect(verifyIranianNationalId("1583250689")).not.toBeFalsy();
 	expect(verifyIranianNationalId("4032152314")).not.toBeFalsy();
@@ -22,5 +36,7 @@ it("Validation of Iranian National Number(code-e Melli)", () => {
 	expect(verifyIranianNationalId("4271467685")).not.toBeFalsy();
 	expect(verifyIranianNationalId("0200203241")).not.toBeFalsy();
 	expect(verifyIranianNationalId("0684159415")).toBeFalsy();
-	expect(verifyIranianNationalId("068415941")).toBeFalsy();
+	expect(verifyIranianNationalId("068415941")).not.toBeFalsy();
+	expect(verifyIranianNationalId("68415941")).not.toBeFalsy();
+	expect(verifyIranianNationalId("787833770")).not.toBeFalsy();
 });


### PR DESCRIPTION
**What:**

- National IDs consisting of a single repeating digit are no more valid in `verifyIranianNationalId()` function

**Why:**

- `verifyIranianNationalId()` considered mono digit IDs valid, but They aren't. This is a [link ](https://www.searchline.ir/idcode) to check valid IDs:


**How:**

- Add an array to filter mono digit IDs 