### PR TITLE
remove : not allowed digits in verifyIranianNationalId

### DIFF
--- a/src/modules/nationalId/index.ts
+++ b/src/modules/nationalId/index.ts
@@ -10,19 +10,6 @@ function verifyIranianNationalId(nationalId?: string | number): boolean | undefi
 	if (!nationalId) return;
 	let code = nationalId.toString();
 	const codeLength = code.length;
-	const notAllowedDigits = {
-		"0000000000": true,
-		"2222222222": true,
-		"3333333333": true,
-		"4444444444": true,
-		"5555555555": true,
-		"6666666666": true,
-		"7777777777": true,
-		"8888888888": true,
-		"9999999999": true,
-	};
-
-	if (code in notAllowedDigits) return false;
 	if (codeLength < 8 || codeLength > 10) return false;
 	code = ("00" + code).substring(codeLength + 2 - 10);
 	if (+code.substring(3, 9) === 0) return false;


### PR DESCRIPTION
hi 
due to this link its wrong to remove national codes that have same numbers 
https://www.iranjib.ir/shownews/56644/%D8%B5%D8%A7%D8%AD%D8%A8-%D8%B4%D9%85%D8%A7%D8%B1%D9%87-%DA%A9%D8%AF%D9%85%D9%84%DB%8C-%DB%B1%DB%B1%DB%B1%DB%B1%DB%B1%DB%B1%DB%B1%DB%B1%DB%B1%DB%B1-%DA%A9%DB%8C%D8%B3%D8%AA%D8%9F/