### PR TITLE
fix: allow getBankNameFromCardNumber for at least 6 num

### DIFF
--- a/src/modules/getBankNameFromCardNumber/index.ts
+++ b/src/modules/getBankNameFromCardNumber/index.ts
@@ -15,7 +15,7 @@ export interface IBank {
 function getBankNameFromCardNumber(digits?: number | string): string | null | undefined {
 	if (!digits) return;
 
-	if (digits && digits.toString().length === 16) {
+	if (digits && digits.toString().length >= 6 && digits.toString().length <= 16) {
 		const code = digits.toString().substr(0, 6);
 		const findBank = (banksCode as IBank[]).find((bank) => bank.code === code);
 

--- a/src/modules/getBankNameFromCardNumber/index.ts
+++ b/src/modules/getBankNameFromCardNumber/index.ts
@@ -15,7 +15,9 @@ export interface IBank {
 function getBankNameFromCardNumber(digits?: number | string): string | null | undefined {
 	if (!digits) return;
 
-	if (digits && digits.toString().length >= 6 && digits.toString().length <= 16) {
+	const digitsLength = digits.toString().length;
+
+	if (digits && digitsLength >= 6 && digitsLength <= 16) {
 		const code = digits.toString().substr(0, 6);
 		const findBank = (banksCode as IBank[]).find((bank) => bank.code === code);
 

--- a/test/getBankNameFromCardNumber.spec.ts
+++ b/test/getBankNameFromCardNumber.spec.ts
@@ -6,7 +6,10 @@ it("Get the name of the bank by bank account number", () => {
 	expect(getBankNameFromCardNumber(6219861034529007)).toEqual("بانک سامان");
 	expect(getBankNameFromCardNumber("6219861034529007")).toEqual("بانک سامان");
 
-	expect(getBankNameFromCardNumber("621986103452900")).toBeNull();
+	expect(getBankNameFromCardNumber(610433)).toEqual("بانک ملت");
+	expect(getBankNameFromCardNumber("50222919")).toEqual("بانک پاسارگاد");
+
+	expect(getBankNameFromCardNumber("50222")).toBeNull();
 	expect(getBankNameFromCardNumber("9999991034529007")).toBeNull();
 	expect(getBankNameFromCardNumber()).toBeUndefined();
 });


### PR DESCRIPTION
To find bank name from card number just need the first six numbers

Resolve issue #257