### PR TITLE
fix: prettier and prettier:ci script path in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,8 +22,8 @@
 		"postrelease": "standard-version && npm run generate:docs",
 		"release:beta": "npm run micro:build",
 		"postrelease:beta": "standard-version --prerelease beta",
-		"prettier": "prettier --write '{src,test}/**/*.{ts,json}' --config .prettierrc.js",
-		"prettier:ci": "prettier --list-different 'src/**/*.{ts,json}' --config .prettierrc.js",
+		"prettier": "prettier --write {src,test}/**/*.{ts,json} --config .prettierrc.js",
+		"prettier:ci": "prettier --list-different src/**/*.{ts,json} --config .prettierrc.js",
 		"generate:docs": "make publish-docs",
 		"prepare": "husky install"
 	},


### PR DESCRIPTION
When running these two command, I get this errors: 

OS: Windows 10
Installed Node.js Version: v18.12.1

commands:
`npm run prettier`
and 
`npm run prettier:ci`

Error:

```
> @persian-tools/persian-tools@3.4.1 prettier
> prettier --write '{src,test}/**/*.{ts,json}' --config .prettierrc.js

[error] No files matching the pattern were found: "'{src,test}/**/*.{ts,json}'".
```