### PR TITLE
revert: add length check to national IDs

### DIFF
--- a/src/modules/nationalId/index.ts
+++ b/src/modules/nationalId/index.ts
@@ -37,7 +37,7 @@ function verifyIranianNationalId(nationalId?: string | number): boolean | undefi
 
 	sum = sum % 11;
 
-	return codeLength === 10 && ((sum < 2 && lastNumber === sum) || (sum >= 2 && lastNumber === 11 - sum)) ;
+	return (sum < 2 && lastNumber === sum) || (sum >= 2 && lastNumber === 11 - sum);
 }
 
 export default verifyIranianNationalId;


### PR DESCRIPTION
#301

checking the length of 10 here will result in tests, to fail
the way validation works here is, if it pass the if guards you will end up having a 10 digit number

for example ->11537027 will become 0011537027