### PR TITLE
fix: maximum call stack error on different locale devices

### DIFF
--- a/src/modules/numberToWords/index.ts
+++ b/src/modules/numberToWords/index.ts
@@ -21,13 +21,13 @@ const numberToWords: NumberToWordsType = (numberValue, options) => {
 	const getWord = (n: number) => numbersWordList[n] ?? "";
 	const addNegativeSuffix = (str: string) => "منفی" + " " + str;
 
-	function transformeToWord(num: number): string {
+	function transformToWord(num: number): string {
 		if (num === 0) return "";
 		if (num <= 9) return getWord(num);
 		else if (num >= 11 && num <= 19) return getWord(num);
 
 		const residual = num <= 99 ? num % 10 : num % 100;
-		return residual === 0 ? getWord(num) : `${getWord(num - residual)} و ${transformeToWord(residual)}`;
+		return residual === 0 ? getWord(num) : `${getWord(num - residual)} و ${transformToWord(residual)}`;
 	}
 
 	/**
@@ -37,18 +37,18 @@ const numberToWords: NumberToWordsType = (numberValue, options) => {
 	 */
 
 	function performer(num: number): string {
-		if (num <= 999) return transformeToWord(num);
+		if (num <= 999) return transformToWord(num);
 
 		const getUnitName = (numberOfZeros: number) =>
 			numberOfZeros === 0 ? "" : numbersWordList[Number.parseInt(`1${"0".repeat(numberOfZeros)}`)];
 
-		const seperated = Number(num).toLocaleString().split(",");
+		const separated = Number(num).toLocaleString("en-US").split(",");
 
-		const numbersArr = seperated
+		const numbersArr = separated
 			.map((value, index) => {
 				const { transformedVal, unitName } = Object.freeze({
-					transformedVal: transformeToWord(Number.parseInt(value, 10)),
-					unitName: getUnitName((seperated.length - (index + 1)) * 3),
+					transformedVal: transformToWord(Number.parseInt(value, 10)),
+					unitName: getUnitName((separated.length - (index + 1)) * 3),
 				});
 
 				return transformedVal ? transformedVal + " " + unitName : "";


### PR DESCRIPTION
as mentioned in #365 there is an error when using `numberToWords` function in a device with a different locale (other than `en-US`). causing the `Maximum call stack size exceeded` error.
the error was when using `toLocaleString` to separate the numbers into chunks it would convert the numbers to the device's locale language. by adding a default locale this issue is resolved.