### PR TITLE
fix:use corrent file name for irGeoJSON import

### DIFF
--- a/src/modules/findProvinceFromCoordinate/index.ts
+++ b/src/modules/findProvinceFromCoordinate/index.ts
@@ -1,4 +1,4 @@
-import { GeoJSONData } from "./IRGeoJSON";
+import { GeoJSONData } from "./irGeoJSON";
 
 interface Point {
 	longitude: number;


### PR DESCRIPTION
Linux systems are sensitive to letter casing.