### PR TITLE
feat: timeAgo func now param added as base for computations

### DIFF
--- a/src/modules/timeAgo/helpers.ts
+++ b/src/modules/timeAgo/helpers.ts
@@ -71,8 +71,8 @@ export function checkFormatDateTime(datetime: string): boolean {
  * - **Standardizing** it (removing hidden chars, zero-padding, etc.)
  * - Converting to a real JS timestamp
  */
-export function getTimeNow(timeZone = "Asia/Tehran", now: Date = new Date()): number {
-	const faLocaleString = now.toLocaleString("fa-IR", {
+export function getTimeNow(timeZone = "Asia/Tehran", override: Date = new Date()): number {
+	const faLocaleString = override.toLocaleString("fa-IR", {
 		year: "numeric",
 		month: "2-digit",
 		day: "2-digit",

--- a/src/modules/timeAgo/helpers.ts
+++ b/src/modules/timeAgo/helpers.ts
@@ -71,8 +71,7 @@ export function checkFormatDateTime(datetime: string): boolean {
  * - **Standardizing** it (removing hidden chars, zero-padding, etc.)
  * - Converting to a real JS timestamp
  */
-export function getTimeNow(timeZone = "Asia/Tehran"): number {
-	const now = new Date();
+export function getTimeNow(timeZone = "Asia/Tehran", now: Date = new Date()): number {
 	const faLocaleString = now.toLocaleString("fa-IR", {
 		year: "numeric",
 		month: "2-digit",

--- a/src/modules/timeAgo/index.ts
+++ b/src/modules/timeAgo/index.ts
@@ -12,7 +12,7 @@ import * as constants from "./constants";
  * @param timeZone e.g. "Asia/Tehran"
  * @returns e.g. "حدود 1 سال قبل" or "اکنون"
  */
-export function timeAgo(datetime: string = "", timeZone = "Asia/Tehran"): string {
+export function timeAgo(datetime: string = "", now: Date = new Date(), timeZone = "Asia/Tehran"): string {
 	// 1) Input must be string
 	if (!isString(datetime)) {
 		throw new TypeError("PersianTools: timeAgo - The input must be a string");
@@ -33,7 +33,7 @@ export function timeAgo(datetime: string = "", timeZone = "Asia/Tehran"): string
 	}
 
 	// 4) Calculate "now" vs. this date
-	const tsTimeNow = getTimeNow(timeZone);
+	const tsTimeNow = getTimeNow(timeZone, now);
 	const tsDateTime = convertToTimeStamp(normalized);
 
 	// 5) Determine the difference

--- a/src/modules/timeAgo/index.ts
+++ b/src/modules/timeAgo/index.ts
@@ -12,7 +12,7 @@ import * as constants from "./constants";
  * @param timeZone e.g. "Asia/Tehran"
  * @returns e.g. "حدود 1 سال قبل" or "اکنون"
  */
-export function timeAgo(datetime: string = "", now: Date = new Date(), timeZone = "Asia/Tehran"): string {
+export function timeAgo(datetime: string = "", since: Date = new Date(), timeZone = "Asia/Tehran"): string {
 	// 1) Input must be string
 	if (!isString(datetime)) {
 		throw new TypeError("PersianTools: timeAgo - The input must be a string");
@@ -33,7 +33,7 @@ export function timeAgo(datetime: string = "", now: Date = new Date(), timeZone 
 	}
 
 	// 4) Calculate "now" vs. this date
-	const tsTimeNow = getTimeNow(timeZone, now);
+	const tsTimeNow = getTimeNow(timeZone, since);
 	const tsDateTime = convertToTimeStamp(normalized);
 
 	// 5) Determine the difference

--- a/test/timeAgo.spec.ts
+++ b/test/timeAgo.spec.ts
@@ -74,6 +74,10 @@ describe("timeAgo", () => {
 			expect(timeAgo(getTime(-14 * 30 * 24 * 60 * 60 * 1000))).toEqual("حدود 1 سال قبل");
 		});
 
+		it("should handle an overriden now", () => {
+			expect(timeAgo(getTime(-3 * 60 * 1000), new Date(Date.now() + (-2 * 60 * 1_000)))).toEqual("1 دقیقه قبل");
+		});
+
 		/**
 		 * **Additional** boundary checks:
 		 * - 59 seconds => "59 ثانیه قبل" (or "چند ثانیه قبل")

--- a/test/timeAgo.spec.ts
+++ b/test/timeAgo.spec.ts
@@ -74,8 +74,8 @@ describe("timeAgo", () => {
 			expect(timeAgo(getTime(-14 * 30 * 24 * 60 * 60 * 1000))).toEqual("حدود 1 سال قبل");
 		});
 
-		it("should handle an overriden now", () => {
-			expect(timeAgo(getTime(-3 * 60 * 1000), new Date(Date.now() + (-2 * 60 * 1_000)))).toEqual("1 دقیقه قبل");
+		it("should handle calculate from since", () => {
+			expect(timeAgo(getTime(-3 * 60 * 1000), new Date(Date.now() + -2 * 60 * 1_000))).toEqual("1 دقیقه قبل");
 		});
 
 		/**


### PR DESCRIPTION
This pull request adds the `now` param with a default of `new Date()` to be used for the base of computations in the case of time-sensitive or financial apps that require server time not user-agent's time.

Fixes #434 