### PR TITLE
🐛 Fix incorrect parsing of spaced hundreds (صد)

### DIFF
--- a/src/modules/wordsToNumber/constants.ts
+++ b/src/modules/wordsToNumber/constants.ts
@@ -37,7 +37,6 @@ export const UNITS = new Map<string, number>([
  * **TEN**: Multiples of 100 up to 900
  */
 export const TEN = new Map<string, number>([
-	["صد", 100],
 	["یکصد", 100],
 	["یک‌صد", 100],
 	["دویست", 200],
@@ -54,6 +53,7 @@ export const TEN = new Map<string, number>([
  * **MAGNITUDE**: Larger scales (thousands, millions, etc.)
  */
 export const MAGNITUDE = new Map<string, number>([
+	["صد", 100],
 	["هزار", 1000],
 	["میلیون", 1000000],
 	["بیلیون", 1000000000],


### PR DESCRIPTION
**Related issue: #436**
---
**Problem**

The word `صد` was previously defined in the `TEN` map (`constants.ts`), which causes it to be treated as an **additive value (100)** rather than a **multiplier (×100)**.

Because of this, spaced Persian numbers such as:`چهار صد` and `سه صد و پنجاه` were parsed incorrectly.

**Example (before)**
```ts
wordsToNumber("چهار صد")        // 104 ❌
wordsToNumber("سه صد و پنجاه")  // 153 ❌
```
This happens because the parser evaluates them as:
```
چهار + صد = 4 + 100
سه + صد + پنجاه = 3 + 100 + 50
```
---
**Solution**

Move `صد` from the `TEN` map to the `MAGNITUDE` map.

This allows the existing parsing logic to correctly treat `صد` as a **multiplier**, consistent with Persian grammar and with how larger magnitudes (هزار, میلیون, etc.) are already handled.

No changes to the parsing logic were required.

**Result (after)**
```ts
wordsToNumber("چهار صد")        // 400 ✅
wordsToNumber("سه صد و پنجاه")  // 350 ✅
wordsToNumber("صد")             // 100 ✅
wordsToNumber("سیصد")           // 300 ✅
```
Both spaced and compact forms are now parsed correctly.

---
**Why this approach**

- Fixes the root cause at the data-model level
- Keeps parsing logic untouched
- Aligns with Persian numeric structure (`n × 100`)
- Does not introduce breaking changes
- Maintains compatibility with existing compact forms (سیصد, چهارصد, …)
---
**Only a single file changed**
`src/modules/wordsToNumber/constants.ts`